### PR TITLE
Fix include dirs for resources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set(SOURCES
 
 add_executable(control WIN32 ${SOURCES})
 
-target_include_directories(control PRIVATE src)
+target_include_directories(control PRIVATE src resources)
 
 target_compile_definitions(control PRIVATE UNICODE _UNICODE)
 


### PR DESCRIPTION
## Summary
- expose `resources` folder to the build by adding it to `target_include_directories`

## Testing
- `cmake ..` *(fails: No CMAKE_RC_COMPILER could be found)*

------
https://chatgpt.com/codex/tasks/task_e_686d7a96d9008321ae9ca84fa29a3f48