### PR TITLE
Fix linking with GDI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,13 +12,13 @@ set(SOURCES
 
 add_executable(control WIN32 ${SOURCES})
 
-target_include_directories(control PRIVATE src)
+target_include_directories(control PRIVATE src resources)
 
 target_compile_definitions(control PRIVATE UNICODE _UNICODE)
 
 if(MSVC)
     target_compile_options(control PRIVATE /EHsc)
-    target_link_libraries(control PRIVATE user32 shell32 comctl32 ole32 shlwapi)
+    target_link_libraries(control PRIVATE user32 shell32 comctl32 ole32 shlwapi gdi32)
 else()
-    target_link_libraries(control PRIVATE ole32 shlwapi comctl32 user32 shell32)
+    target_link_libraries(control PRIVATE user32 shell32 comctl32 ole32 shlwapi gdi32)
 endif()


### PR DESCRIPTION
## Summary
- link gdi32 for CreateFontW
- add `resources` directory to include path
- keep library order consistent

## Testing
- `cmake ..` *(fails: No CMAKE_RC_COMPILER could be found)*

------
https://chatgpt.com/codex/tasks/task_e_686d7a96d9008321ae9ca84fa29a3f48